### PR TITLE
Fix empty object output: if object has no keys

### DIFF
--- a/src/controllers/plugin-edit.js
+++ b/src/controllers/plugin-edit.js
@@ -22,7 +22,7 @@
                             $scope.checkBoxes[key][value.enum[i]] = false;
                         }
                     } else if (typeof value.default !== 'undefined') {
-                        $scope.formInput.config[key] = value.default;
+                        $scope.formInput.config[key] = Object.keys(value.default).length === 0 ? '': value.default;
                     }
                 });
 


### PR DESCRIPTION
The layout is dynamically generated and sometimes there is default values.

This fix is required when the default is an empty object avoiding the string [Object object] in the input box.